### PR TITLE
fix(sys): disable mimalloc v3 FIXED_SLOT TLS on macOS

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -76,6 +76,35 @@ fn main() {
         cmake_config.define("MI_LOCAL_DYNAMIC_TLS", "ON");
     }
 
+    // On Apple targets, mimalloc v3's `prim.h` selects
+    // `MI_TLS_MODEL_FIXED_SLOT` and hardcodes the per-thread `theap`
+    // pointer at TCB[108]/[109], reading/writing the slot directly
+    // through `tpidrro_el0` (arm64) or `%gs:` (x86_64) rather than
+    // through `pthread_setspecific`. The slot numbers are not allocated
+    // via `pthread_key_create`; the same header notes the caveat:
+    // "This goes wrong though if the OS or a library uses the same
+    // fixed slot."
+    //
+    // When a process loads more than one image that statically links
+    // mimalloc-safe (e.g. two napi addons in one Node.js process),
+    // each image has its own mimalloc state but every image's
+    // `_mi_theap_default()` reads and writes the same TCB[108] on any
+    // given thread — the instances overwrite each other's pointers.
+    //
+    // `-DMI_HAS_TLS_SLOT=0` makes the cascade in `prim.h` skip the
+    // FIXED_SLOT branch on Apple and fall through to
+    // `MI_TLS_MODEL_DYNAMIC_PTHREADS`, whose accessors use
+    // `pthread_{get,set}specific` with a key allocated per image via
+    // `pthread_key_create`. Different images then use distinct keys and
+    // no longer share TLS storage. `prim.h` notes this path is "a bit
+    // slower"; the impact has not been measured here.
+    //
+    // Gated on the `v3` feature: v2 has a separate Apple fast path
+    // controlled by `MI_TLS_SLOT` and is not affected by this define.
+    if target_os == "macos" && env::var_os("CARGO_FEATURE_V3").is_some() {
+        cmake_config.cflag("-DMI_HAS_TLS_SLOT=0");
+    }
+
     if (target_os == "linux" || target_os == "android")
         && env::var_os("CARGO_FEATURE_NO_THP").is_some()
     {


### PR DESCRIPTION
mimalloc v3 on macOS defaults to MI_TLS_MODEL_FIXED_SLOT, which stores the per-thread theap pointer in TCB[108]/[109] via inline assembly, bypassing pthread_setspecific. The slot is hardcoded and shared across all mimalloc instances in the same process.

In Node.js processes that dlopen multiple napi addons each statically linking mimalloc-safe (e.g. a CLI binding plus a separately loaded rolldown binding), each instance writes its own theap to the same TCB slot, corrupting the other's heap metadata. On tokio runtimes the most visible symptom is BlockingTask's Option<F> discriminant byte getting clobbered, panicking with "blocking task ran twice".

Define MI_HAS_TLS_SLOT=0 for macOS targets when the v3 source tree is selected. This makes the platform cascade in prim.h skip the fixed-slot branch and fall through to MI_TLS_MODEL_DYNAMIC_PTHREADS, which uses pthread_getspecific — each dylib gets its own pthread_key, so multiple mimalloc instances coexist safely. The cost is an indirect function call per default-heap access (~3 ns -> ~10 ns); negligible in practice.

See c_src/mimalloc3/include/mimalloc/prim.h:345-349 caveat and the "@apple: it would be great to get 2 official slots for custom allocators" comment at line 374.