### PR TITLE
fix(sys): route Windows MSVC build to v3 source when v3 feature is on

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -139,10 +139,20 @@ fn build_mimalloc_win() {
     let mut build = cc::Build::new();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("target_arch not defined!");
 
+    // Route to the v3 source tree when the `v3` feature is enabled,
+    // mirroring the cmake branch above. Both trees expose `src/static.c`
+    // as a single translation unit that pulls in all the platform .c
+    // files, so the cc-rs single-file build pattern works for either.
+    let source_dir = if env::var_os("CARGO_FEATURE_V3").is_some() {
+        "./c_src/mimalloc3"
+    } else {
+        "./c_src/mimalloc"
+    };
+
     build
-        .include("./c_src/mimalloc/include")
-        .include("./c_src/mimalloc/src")
-        .file("./c_src/mimalloc/src/static.c")
+        .include(format!("{source_dir}/include"))
+        .include(format!("{source_dir}/src"))
+        .file(format!("{source_dir}/src/static.c"))
         .define("MI_BUILD_SHARED", "0")
         .cpp(true)
         .warnings(false)


### PR DESCRIPTION
## Problem

`build_mimalloc_win()` hardcodes the v2 source path:

```rust
build
    .include("./c_src/mimalloc/include")
    .include("./c_src/mimalloc/src")
    .file("./c_src/mimalloc/src/static.c")
```

So on `*-pc-windows-msvc` targets the `v3` cargo feature is silently
ignored and v2 is built regardless. The cmake branch above already
switches between `c_src/mimalloc` and `c_src/mimalloc3` based on the
same feature; the Windows path was simply never updated when the v3
tree was introduced.

## Fix

Mirror the cmake branch and select the source tree based on
`CARGO_FEATURE_V3`:

```rust
let source_dir = if env::var_os("CARGO_FEATURE_V3").is_some() {
    "./c_src/mimalloc3"
} else {
    "./c_src/mimalloc"
};

build
    .include(format!("{source_dir}/include"))
    .include(format!("{source_dir}/src"))
    .file(format!("{source_dir}/src/static.c"))
```

Both source trees ship `src/static.c` as a single translation unit
that `#include`s all the .c files in `src/` plus
`prim/prim.c` (which in turn picks the per-OS `prim/<os>/prim.c`), so
the cc-rs single-file build pattern works for either version unchanged.