### PR TITLE
fix(sys): use THREAD_LOCAL TLS for mimalloc v3 on Apple

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/microsoft/mimalloc.git
 [submodule "libmimalloc-sys/c_src/mimalloc3"]
 	path = libmimalloc-sys/c_src/mimalloc3
-	url = https://github.com/microsoft/mimalloc.git
+	url = https://github.com/napi-rs/mimalloc.git
+	branch = dev3

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -76,34 +76,10 @@ fn main() {
         cmake_config.define("MI_LOCAL_DYNAMIC_TLS", "ON");
     }
 
-    // On Apple targets, mimalloc v3's `prim.h` selects
-    // `MI_TLS_MODEL_FIXED_SLOT` and hardcodes the per-thread `theap`
-    // pointer at TCB[108]/[109], reading/writing the slot directly
-    // through `tpidrro_el0` (arm64) or `%gs:` (x86_64) rather than
-    // through `pthread_setspecific`. The slot numbers are not allocated
-    // via `pthread_key_create`; the same header notes the caveat:
-    // "This goes wrong though if the OS or a library uses the same
-    // fixed slot."
-    //
-    // When a process loads more than one image that statically links
-    // mimalloc-safe (e.g. two napi addons in one Node.js process),
-    // each image has its own mimalloc state but every image's
-    // `_mi_theap_default()` reads and writes the same TCB[108] on any
-    // given thread — the instances overwrite each other's pointers.
-    //
-    // `-DMI_HAS_TLS_SLOT=0` makes the cascade in `prim.h` skip the
-    // FIXED_SLOT branch on Apple and fall through to
-    // `MI_TLS_MODEL_DYNAMIC_PTHREADS`, whose accessors use
-    // `pthread_{get,set}specific` with a key allocated per image via
-    // `pthread_key_create`. Different images then use distinct keys and
-    // no longer share TLS storage. `prim.h` notes this path is "a bit
-    // slower"; the impact has not been measured here.
-    //
-    // Gated on the `v3` feature: v2 has a separate Apple fast path
-    // controlled by `MI_TLS_SLOT` and is not affected by this define.
-    if target_os == "macos" && env::var_os("CARGO_FEATURE_V3").is_some() {
-        cmake_config.cflag("-DMI_HAS_TLS_SLOT=0");
-    }
+    // Note: the previous `-DMI_HAS_TLS_SLOT=0` workaround for Apple has been
+    // replaced by a vendored source patch in our mimalloc fork (napi-rs/mimalloc
+    // dev3) that routes Apple to `MI_TLS_MODEL_THREAD_LOCAL + MI_TLS_RECURSE_GUARD`
+    // directly in `include/mimalloc/prim.h`. See that patch for the full rationale.
 
     if (target_os == "linux" || target_os == "android")
         && env::var_os("CARGO_FEATURE_NO_THP").is_some()


### PR DESCRIPTION
## Summary

Fixes two distinct SIGABRT failure modes on macOS by switching mimalloc v3's
Apple TLS strategy from `MI_TLS_MODEL_FIXED_SLOT` to `MI_TLS_MODEL_THREAD_LOCAL`
with `MI_TLS_RECURSE_GUARD`.

The patch lives directly in our mimalloc fork
([napi-rs/mimalloc](https://github.com/napi-rs/mimalloc), `dev3` branch =
upstream v3.3.2 + this patch). The submodule is repointed at that fork, so the
working tree stays clean and we don't have to rewrite `prim.h` at build time.

Supersedes #67.

## Problem

mimalloc v3 unconditionally enables `FIXED_SLOT` on macOS, storing the
per-thread heap pointer in TCB[108] — a **hardcoded slot shared by all .node
addons** in the same process. This causes two separate SIGABRTs:

### Mode A: multiple addons in one process → 100% SIGABRT

When two napi addons each statically link mimalloc v3, the second addon
**crashes immediately on load** (root cause of
[vite-plus #1581](https://github.com/voidzero-dev/vite-plus/pull/1581)).

Addon B reads Addon A's heap pointer from TCB[108], sees it's non-NULL, and
concludes "already initialized" (the check at `internal.h:573` only tests for
NULL — it doesn't verify ownership). B skips its own initialization, then runs
with A's heap data + B's uninitialized internal state → inconsistency →
SIGABRT.

```mermaid
sequenceDiagram
  participant TCB as TCB[108]<br/>(shared by all addons)
  participant A as Addon A
  participant B as Addon B

  A->>TCB: write heap_A
  B->>TCB: read → heap_A (non-NULL → "already initialized" → skip B's own init)
  Note over B: A's heap + B's zeroed state → 💥 SIGABRT
```

### Mode B: #67 switched to DYNAMIC_PTHREADS → 5–15% SIGABRT on exit

PR #67 used `-DMI_HAS_TLS_SLOT=0` to route Apple to DYNAMIC_PTHREADS, which
stores heap pointers via `pthread_setspecific` with a per-addon key. This
fixed Mode A, but introduced an unrecoverable state during process exit.

When the process exits, mimalloc's `__attribute__((destructor))` runs
`mi_process_done` (`init.c:1149`), which deletes the pthread key and zeros it
(`init.c:906-907`). However, the one-time flag that guards key creation
(`mi_atomic_do_once` at `atomic.h:557`) **never resets** — so the key can
never be recreated.

Meanwhile, `exit()` only runs cleanup on the main thread — **background
threads (rayon workers from `oxc_cfg → oxc_index → rayon`) are still alive**.
When they next allocate, the key is zero, the slow path allocates a new heap
but can't store it (key is 0, `setspecific` skipped, `do_once` says "already
created"), and alloc returns NULL → SIGABRT.

```mermaid
sequenceDiagram
  participant Dtor as Main thread destructor
  participant Key as pthread key
  participant Worker as Background thread (rayon)

  Dtor->>Key: delete key, set to 0
  Note over Worker: still alive (exit() doesn't stop other threads)
  Worker->>Key: alloc → read key → 0 → NULL
  Worker->>Worker: slow path: allocate heap (OK) → try to recreate key → do_once says "already done" → skip → can't store heap
  Note over Worker: alloc returns NULL → 💥 SIGABRT
```

### Why v2 didn't have either issue

v2's `MI_TLS_SLOT 89` is **only enabled when `MI_MALLOC_OVERRIDE` is on**
(`prim.h:350`). In non-override mode (standard napi addon configuration), v2
falls through to `__thread` (THREAD_LOCAL) — per-image isolation, no key to
delete. **v3 made FIXED_SLOT unconditional — this is the regression.**

## Solution

Switch Apple to `THREAD_LOCAL + RECURSE_GUARD`. The two changes that effect
this:

1. **In our fork** ([napi-rs/mimalloc@9a15529d](https://github.com/napi-rs/mimalloc/commit/9a15529dc99d27fb7983eed37b4290b541834c86)) — patch `include/mimalloc/prim.h`:

    ```diff
     #if defined(_WIN32)
    -  #define MI_TLS_MODEL_DYNAMIC_WIN32        1    
    -#elif defined(__APPLE__) && MI_HAS_TLS_SLOT && !defined(__POWERPC__)
    -  #define MI_TLS_MODEL_FIXED_SLOT           1
    -  #define MI_TLS_MODEL_FIXED_SLOT_DEFAULT   108
    -  #define MI_TLS_MODEL_FIXED_SLOT_CACHED    109
    -#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__ANDROID__)
    -  #define MI_TLS_MODEL_DYNAMIC_PTHREADS     1
    +  #define MI_TLS_MODEL_DYNAMIC_WIN32        1
    +#elif defined(__APPLE__) && !defined(__POWERPC__)
    +  #define MI_TLS_MODEL_THREAD_LOCAL         1
    +  #ifndef MI_TLS_RECURSE_GUARD
    +  #define MI_TLS_RECURSE_GUARD              1
    +  #endif
    +#elif defined(__OpenBSD__) || defined(__ANDROID__)
    +  #define MI_TLS_MODEL_DYNAMIC_PTHREADS     1
     #else
       #define MI_TLS_MODEL_THREAD_LOCAL         1
     #endif
    ```

2. **In this repo** — repoint the `mimalloc3` submodule at our fork's `dev3`
   branch and drop the `-DMI_HAS_TLS_SLOT=0` cflag (the workaround #67 added).

### Why THREAD_LOCAL fixes both modes

`__thread` variables are compiler-generated templates — each thread gets its
own copy on first access (allocated by the OS). Combined with `hidden`
visibility (each .node has its own symbol), this gives **per-addon ×
per-thread** isolation:

```mermaid
flowchart LR
  subgraph "Fixes Mode A"
    hidden["Each .node has its own<br/>__mi_theap_default variable"]
    hidden --> noTCB["TCB[108] is no longer used<br/>Addons cannot interfere"]
  end

  subgraph "Fixes Mode B"
    noKey["No pthread_key involved"]
    noKey --> noDel["No key → nothing to delete<br/>→ no unrecoverable state"]
  end
```

- **Mode A**: different addons' `__thread` variables have different
  addresses (hidden visibility), even on the same thread.
- **Mode B**: `__thread` variables live and die with the thread — no
  `pthread_key_delete`, destructors cannot break anything.
- **RECURSE_GUARD**: on macOS, first access to a `__thread` variable
  triggers dyld storage allocation (which internally calls `calloc`).
  If mimalloc hasn't finished initializing yet, this could recurse.
  `RECURSE_GUARD` short-circuits the fast path with a plain bool
  (`_mi_process_is_initialized`) until init completes — no `__thread`
  access, no dyld, no recursion.
- **thread-id**: `MI_HAS_TLS_SLOT` stays at default 1 — thread-id still uses
  Apple's system slot 0 (no conflict).

### Why vendor the patch in the fork (not build.rs)

The Apple branch in upstream `prim.h` is an unconditional `#define` with no
`#ifndef` guard, so neither `-DMI_TLS_MODEL_THREAD_LOCAL=1` nor
`-DMI_HAS_TLS_SLOT=0` produces the desired branch. The only way to get
`THREAD_LOCAL` on Apple is to modify the source.

An earlier iteration of this PR rewrote `prim.h` inside `build.rs` at build
time. That works but is awkward: it mutates the submodule's working tree
in place, needs a marker comment to be idempotent, and complicates fresh
clones. Carrying the patch on a branch of our fork (`napi-rs/mimalloc:dev3`)
keeps the submodule pristine on disk, makes the change visible in `git
diff` against upstream, and survives `git submodule update --force`. When
we want to pull in a newer upstream v3 release, we rebase our patch on top.

## Verification

- `cargo build --features v3 --release` from a clean target succeeds on
  `aarch64-apple-darwin`.
- `nm libmimalloc.a` on the built artifact shows `___mi_theap_default$tlv$init`
  / `___mi_theap_cached$tlv$init` symbols (macOS thread-local-variable
  initializers) — confirming `__thread` storage is in effect. Under FIXED_SLOT
  these symbols would not exist.

## Test plan

- [ ] CI build on macOS (arm64 + x64) with `v3` feature
- [ ] CI build on Linux / Windows with and without `v3` (regression check —
      patch only changes Apple branch)
- [ ] Confirm reproducer from vite-plus #1581 no longer crashes
- [ ] Run a v3-linked binary that spawns rayon workers and exits, confirm no
      SIGABRT during teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)