### PR TITLE
fix(sys): mimalloc3 v3.5.1 + fix for the process-init thread's thread-done hook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/microsoft/mimalloc.git
 [submodule "libmimalloc-sys/c_src/mimalloc3"]
 	path = libmimalloc-sys/c_src/mimalloc3
-	url = https://github.com/microsoft/mimalloc.git
-	branch = dev3
+	url = https://github.com/napi-rs/mimalloc.git
+	branch = fix/first-thread-done


### PR DESCRIPTION
### Background

mimalloc v3.5.0 (shipped in libmimalloc-sys2 0.1.61 / mimalloc-safe 0.1.65 by #92) never associates the process-init thread's theap with the pthread thread-done key. If the first thread that touches the allocator exits — a Node.js `worker_threads` worker that loads the addon first, then exits — `_mi_thread_done` never runs for it, its theap stays registered with its thread id, and the next thread that reuses that pthread TCB aborts in debug builds:

```
mimalloc: assertion failed: at "src/init.c":327, _mi_thread_init_with_heap
  assertion: "theap==NULL"
```

Release builds skip the assert but leak the dead thread's theap and pages. Linux only in practice (macOS enables `MI_TLS_RECURSE_GUARD`, which makes the new thread adopt the stale theap). Upstream culprit: microsoft/mimalloc@5d9cb381 ("remove static main theap and tld"); v3.4.5 was the last good tag. Reported upstream with the fix: microsoft/mimalloc#1393. Found via rolldown/rolldown#10268 CI (`watch debounce timers survive a worker-first registrant that exited`), which pinned `mimalloc-safe = "=0.1.64"` as a stopgap.

### Changes

- **`.gitmodules`** — `mimalloc3` url `microsoft/mimalloc` → `napi-rs/mimalloc`, branch `fix/first-thread-done` (same approach as #71).
- **`mimalloc3`** — `18b08671` (v3.5.0) → `1e5d14ca` = upstream **v3.5.1** + the 11-line `src/init.c` fix (associate the already-initialized default theap right after `_mi_prim_thread_init_auto_done()`). v3.5.1 additionally carries the upstream fix for microsoft/mimalloc#1371 (realloc assert on a new thread).
- No change to `build.rs`, the v2 submodule, or the Rust sources.

### Verification (Docker linux/arm64, node 22, debug + release builds of `example/` with `--features v3`)

| tree | Node worker-first flow (1 / 64 / 64+4 concurrent workers) | Rust std threads reusing the dead TCB | release | `cargo test --features v3` | sys-test |
|---|---|---|---|---|---|
| v3.5.0 / v3.5.1 unfixed | assertion + SIGABRT | assertion + SIGABRT | OK (leaks) | — | — |
| `1e5d14ca` | OK | OK | OK | 6/6 | 251/251 |

Bisect over v3.4.5..v3.5.0 (7 steps) isolates 5d9cb381. The v2 line (`c_src/mimalloc` v2.5.0) does not have the gap and passes the same flow.

Once released, rolldown can drop its `=0.1.64` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T34fMrYCf2V13Mg8BKmnda

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches process-wide allocator and per-thread teardown in native code; wrong behavior can cause crashes or leaks in multi-threaded hosts (e.g. Node `worker_threads`), though scope is limited to the v3 submodule.
> 
> **Overview**
> **Repoints the `mimalloc3` git submodule** from `microsoft/mimalloc` (`dev3`) to **`napi-rs/mimalloc`** on branch **`fix/first-thread-done`**, matching the prior fork-based workflow used for targeted allocator fixes.
> 
> That branch carries **mimalloc v3.5.1** plus a small **`src/init.c` change** so the process-init thread’s default heap is registered with the pthread thread-done hook. Without it, a worker thread that is the first allocator user and then exits can leave a stale heap on reused pthread TCBs (debug abort in `_mi_thread_init_with_heap`, leaks in release on Linux).
> 
> **No Rust `build.rs` or crate source changes** in this diff; consumers get the fix via the updated vendored mimalloc3 tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd53da2996119c6caef5c93a8401e7a6d89d3f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->